### PR TITLE
Feature/getresult standalone

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .settings/
 .classpath
 .project
+wps-client.log

--- a/src/main/java/org/n52/geoprocessing/wps/client/WPSClientSession.java
+++ b/src/main/java/org/n52/geoprocessing/wps/client/WPSClientSession.java
@@ -68,6 +68,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import org.n52.geoprocessing.wps.client.model.Result;
 
 /**
  * Contains some convenient methods to access and manage Web Processing Services
@@ -789,4 +790,20 @@ public final class WPSClientSession {
             LOGGER.info("Property delayForAsyncRequests not present, defaulting to: " + delayForAsyncRequests);
         }
     }
+    
+    public Result retrieveProcessResult(String url, String jobId) throws IOException, WPSClientException {
+        try {
+            String targetUrl = this.createGetResultURLWPS20(url, jobId);
+            Object result = retrieveResponseOrExceptionReportInpustream(new URL(targetUrl));
+            
+            if (result != null && result instanceof Result) {
+                return (Result) result;
+            }
+            
+            throw new WPSClientException("Invalid response from WPS: " + result);
+        } catch (MalformedURLException ex) {
+            throw new IOException(ex.getMessage(), ex);
+        }
+    }
+    
 }

--- a/src/main/java/org/n52/geoprocessing/wps/client/WPSClientSession.java
+++ b/src/main/java/org/n52/geoprocessing/wps/client/WPSClientSession.java
@@ -79,7 +79,7 @@ import org.n52.geoprocessing.wps.client.model.Result;
  * @author bpross,foerster
  */
 
-public final class WPSClientSession {
+public class WPSClientSession {
 
     public static final String VERSION_100 = "1.0.0";
 
@@ -118,7 +118,7 @@ public final class WPSClientSession {
      * Initializes a WPS client session.
      *
      */
-    private WPSClientSession() {
+    public WPSClientSession() {
         loggedServices = new HashMap<String, WPSCapabilities>();
         processDescriptions = new HashMap<String, List<Process>>();
         httpClientBuilder = HttpClientBuilder.create();
@@ -790,20 +790,20 @@ public final class WPSClientSession {
             LOGGER.info("Property delayForAsyncRequests not present, defaulting to: " + delayForAsyncRequests);
         }
     }
-    
+
     public Result retrieveProcessResult(String url, String jobId) throws IOException, WPSClientException {
         try {
             String targetUrl = this.createGetResultURLWPS20(url, jobId);
             Object result = retrieveResponseOrExceptionReportInpustream(new URL(targetUrl));
-            
+
             if (result != null && result instanceof Result) {
                 return (Result) result;
             }
-            
+
             throw new WPSClientException("Invalid response from WPS: " + result);
         } catch (MalformedURLException ex) {
             throw new IOException(ex.getMessage(), ex);
         }
     }
-    
+
 }


### PR DESCRIPTION
pull request with two separate aspects:

1. allow Process Result retrieval without an Execute execution beforehand to support decoupled components (one doing the execute, the other retrieving the result)
1. removing the restrictions on `WPSClientSession` (`final` class and `private` constructor) to improve testability, e.g. with Mockito.