### PR TITLE
fix issue with Type tag in Keywords leading to UnexpectedTagException

### DIFF
--- a/src/main/java/org/n52/geoprocessing/wps/client/decoder/stream/GetCapabilities100ResponseDecoder.java
+++ b/src/main/java/org/n52/geoprocessing/wps/client/decoder/stream/GetCapabilities100ResponseDecoder.java
@@ -418,7 +418,11 @@ public class GetCapabilities100ResponseDecoder extends AbstractElementXmlStreamR
                 StartElement elem = event.asStartElement();
                 if (elem.getName().equals(OWS11Constants.Elem.QN_KEYWORD)) {
                     keywords.add(reader.getElementText());
-                } else {
+                } else if(elem.getName().equals(OWS11Constants.Elem.QN_TYPE)){
+                    //ignore Type tag
+                    //TODO parse Type tag properly
+                }
+                else {
                     throw unexpectedTag(elem);
                 }
             } else if (event.isEndElement()) {

--- a/src/main/java/org/n52/geoprocessing/wps/client/decoder/stream/GetCapabilitiesResponseDecoder.java
+++ b/src/main/java/org/n52/geoprocessing/wps/client/decoder/stream/GetCapabilitiesResponseDecoder.java
@@ -412,7 +412,10 @@ public class GetCapabilitiesResponseDecoder extends AbstractElementXmlStreamRead
                 StartElement elem = event.asStartElement();
                 if (elem.getName().equals(OWSConstants.Elem.QN_KEYWORD)) {
                     keywords.add(reader.getElementText());
-                } else {
+                }else if(elem.getName().equals(OWSConstants.Elem.QN_TYPE)){
+                     //ignore Type tag
+                    //TODO parse Type tag properly
+                }else {
                     throw unexpectedTag(elem);
                 }
             } else if (event.isEndElement()) {

--- a/src/test/resources/org/n52/geoprocessing/wps/client/52n-capabilities-response100.xml
+++ b/src/test/resources/org/n52/geoprocessing/wps/client/52n-capabilities-response100.xml
@@ -30,6 +30,7 @@
 			<ows:Keyword>WPS</ows:Keyword>
 			<ows:Keyword>geospatial</ows:Keyword>
 			<ows:Keyword>geoprocessing</ows:Keyword>
+                        <ows:Type codeSpace="ISOTC211/19115">theme</ows:Type>
 		</ows:Keywords>
 		<ows:ServiceType>WPS</ows:ServiceType>
 		<ows:ServiceTypeVersion>1.0.0</ows:ServiceTypeVersion>

--- a/src/test/resources/org/n52/geoprocessing/wps/client/52n-capabilities-response20.xml
+++ b/src/test/resources/org/n52/geoprocessing/wps/client/52n-capabilities-response20.xml
@@ -23,6 +23,7 @@
     <ows:Keywords>
       <ows:Keyword>OGC</ows:Keyword>
       <ows:Keyword>WPS 2.0</ows:Keyword>
+      <ows:Type codeSpace="ISOTC211/19115">theme</ows:Type>
     </ows:Keywords>
     <ows:ServiceType>OGC:WPS</ows:ServiceType>
     <ows:ServiceTypeVersion>2.0.0</ows:ServiceTypeVersion>


### PR DESCRIPTION
Suppress exception caused by _Type_ tag within a _Keywords_ tag which is allowed according to:
https://schemas.opengis.net/ows/1.0.0/ows19115subset.xsd
https://schemas.opengis.net/ows/2.0/ows19115subset.xsd

This hotfix simply ignores the Type tag instead of parsing it properly.